### PR TITLE
Add survivor gender number to README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,51 +3,51 @@ If `DLC File ID` is blank then it's either stored in `Content -> Data -> Dlc -> 
 
 ## Survivors
 
-| Character               | Codename   | DLC File ID   |   ID |
-| :--- | :--- | :--- | :--- |
-| Dwight Fairfield        | Dwight     |               |    0 |
-| Meg Thomas              | Meg        |               |    1 |
-| Claudette Morel         | Claudette  |               |    2 |
-| Jake Park               | Jake       |               |    3 |
-| Nea Karlsson            | Nea        |               |    4 |
-| Laurie Strode           | Laurie     | DLC2          |    5 |
-| Ace Visconti            | Ace        |               |    6 |
-| William "Bill" Overbeck | Bill       | L4D           |    7 |
-| Feng Min                | Feng       | DLC4          |    8 |
-| David King              | Smoke      | DLC5          |    9 |
-| Kate Denson             | Kate       | Guam          |   10 |
-| Quentin Smith           | Quentin    | England       |   11 |
-| Detective Tapp          | Eric       | Finland       |   12 |
-| Adam Francis            | Adam       | Haiti         |   13 |
-| Jeff Johansen           | Jeff       | Kenya         |   14 |
-| Jane Romero             | Jane       | Mali          |   15 |
-| Ashley J. Williams      | Ash        | Ash           |   16 |
-| Nancy Wheeler           | Nancy      | Qatar_F         |   17 |
-| Steve Harrington        | Steve      | Qatar_M         |   18 |
-| Yui Kimura              | Yui        | Sweden        |   19 |
-| Zarina Kassir           | Zarina     | Ukraine       |   20 |
-| Cheryl Mason            | S22        | Wales         |   21 |
-| Felix Richter           | S23        | Yemen         |   22 |
-| Élodie Rakoto           | S24        | Aurora        |   23 |
-| Yun-Jin Lee             | S25        | Comet         |   24 |
-| Jill Valentine          | S26        | Eclipse       |   25 |
-| Leon S. Kennedy         | S27        | Eclipse       |   26 |
-| Mikaela Reid            | S28        | Hubble        |   27 |
-| Jonah Vasquez           | S29        | Ion           |   28 |
-| Yoichi Asakawa          | S30        | Kepler        |   29 |
-| Haddie Kaur             | S31        | Meteor        |   30 |
-| Ada Wong                | S32        | Orion         |   31 |
-| Rebecca Chambers        | S33        | Orion         |   32 |
-| Vittorio Toscano        | S34        | Quantum       |   33 |
-| Thalita Lyra            | S35        | Saturn        |   34 |
-| Renato Lyra             | S36        | Saturn        |   35 |
-| Gabriel Soma            | S37        | Umbra         |   36 |
-| Nicolas Cage            | S38        | Venus         |   37 |
-| Ellen Ripley            | S39        | Wormhole      |   38 |
-| Alan Wake               | S40        | Zodiac        |   39 |
-| Sable Ward              | S41        | Applepie      |   40 |
-| Aestri Yazar            | S42        |               |   41 |
-| Lara Croft              | S43        | Donut         |   42 |
+|   # | Character               | Codename   | DLC File ID   |   ID | Gender # |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|   1 | Dwight Fairfield        | Dwight     |               |    0 | M01 |
+|   2 | Meg Thomas              | Meg        |               |    1 | F01 |
+|   3 | Claudette Morel         | Claudette  |               |    2 | F02 |
+|   4 | Jake Park               | Jake       |               |    3 | M02 |  
+|   5 | Nea Karlsson            | Nea        |               |    4 | F03 |
+|   6 | Laurie Strode           | Laurie     | DLC2          |    5 | F04 |
+|   7 | Ace Visconti            | Ace        |               |    6 | M03 |
+|   8 | William "Bill" Overbeck | Bill       | L4D           |    7 | M04 |
+|   9 | Feng Min                | Feng       | DLC4          |    8 | F05 |
+|  10 | David King              | Smoke      | DLC5          |    9 | M05 |
+|  11 | Kate Denson             | Kate       | Guam          |   10 | F06 |
+|  12 | Quentin Smith           | Quentin    | England       |   11 | M06 |
+|  13 | Detective Tapp          | Eric       | Finland       |   12 | M07 |
+|  14 | Adam Francis            | Adam       | Haiti         |   13 | M08 |
+|  15 | Jeff Johansen           | Jeff       | Kenya         |   14 | M09 |
+|  16 | Jane Romero             | Jane       | Mali          |   15 | F07 |
+|  17 | Ashley J. Williams      | Ash        | Ash           |   16 | M10 |   
+|  18 | Nancy Wheeler           | Nancy      | Qatar_F       |   17 | F08 |
+|  19 | Steve Harrington        | Steve      | Qatar_M       |   18 | M11 |   
+|  20 | Yui Kimura              | Yui        | Sweden        |   19 | F09 |
+|  21 | Zarina Kassir           | Zarina     | Ukraine       |   20 | F10 |
+|  22 | Cheryl Mason            | S22        | Wales         |   21 | F11 |
+|  23 | Felix Richter           | S23        | Yemen         |   22 | M12 |
+|  24 | Élodie Rakoto           | S24        | Aurora        |   23 | F12 |
+|  25 | Yun-Jin Lee             | S25        | Comet         |   24 | F13 |
+|  26 | Jill Valentine          | S26        | Eclipse       |   25 | F14 |
+|  27 | Leon S. Kennedy         | S27        | Eclipse       |   26 | M13 |
+|  28 | Mikaela Reid            | S28        | Hubble        |   27 | F15 |
+|  29 | Jonah Vasquez           | S29        | Ion           |   28 | M14 |
+|  30 | Yoichi Asakawa          | S30        | Kepler        |   29 | M15 |
+|  31 | Haddie Kaur             | S31        | Meteor        |   30 | F16 |
+|  32 | Ada Wong                | S32        | Orion         |   31 | F17 |
+|  33 | Rebecca Chambers        | S33        | Orion         |   32 | F18 |
+|  34 | Vittorio Toscano        | S34        | Quantum       |   33 | M16 |
+|  35 | Thalita Lyra            | S35        | Saturn        |   34 | F19 |
+|  36 | Renato Lyra             | S36        | Saturn        |   35 | M17 |
+|  37 | Gabriel Soma            | S37        | Umbra         |   36 | M18 |
+|  38 | Nicolas Cage            | S38        | Venus         |   37 | M19 |
+|  39 | Ellen Ripley            | S39        | Wormhole      |   38 | F20 |
+|  40 | Alan Wake               | S40        | Zodiac        |   39 | M20 |
+|  41 | Sable Ward              | S41        | Applepie      |   40 | F21 |
+|  42 | Aestri Yazar            | S42        |               |   41 | M21 |
+|  43 | Lara Croft              | S43        | Donut         |   42 | M22 |
 
 ## Killers
 


### PR DESCRIPTION
Add survivor number and gender number. Gender number is useful for identifying character blueprints and audio data files.